### PR TITLE
CPLAT-14332: Support custom build args; always apply delete-conflicting-outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.1
+## 2.1.0
 
 - Add support for `--build-args` to the browser aggregation feature.
 - Hardcode `--delete-conflicting-outputs` in the first `build_runner` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.1
+
+- Add support for `--build-args` to the browser aggregation feature.
+- Hardcode `--delete-conflicting-outputs` in the first `build_runner` command
+that is executed by the browser aggregation feature.
+- Update the "args" mode of the browser aggregation feature so it doesn't
+parrot back the build arguments it uses when running the build_runner.
+
 ## 2.0.0
 
 [browser-aggregation]: /README.md#aggregating-browser-tests

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -268,7 +268,8 @@ class DartTestYamlBuilder extends Builder {
     platforms: [chrome]
     paths:''');
 
-    final aggregateTests = buildStep.findAssets(Glob('test/**_template.browser_aggregate_test.dart'));
+    final aggregateTests = buildStep
+        .findAssets(Glob('test/**_template.browser_aggregate_test.dart'));
     await for (final testId in aggregateTests) {
       log.fine('Found aggregate test: ${testId.path}');
       contents.writeln('      - ${testId.path}');


### PR DESCRIPTION
### Problem:
When using the new browser aggregation in w_outline, via corresponding updates to dart_dev_workiva that allow you to run `ddev test --browser-aggregation`, I discovered that the first `build_runner` command run by the browser aggregation tool needs to include `--delete-conflicting-outputs` since it writes its outputs to source and we expect consumers to check those in.

When thinking about how this might be consumed in wdesk_sdk, it dawned on me wdesk_sdk is using a custom build.test.yaml file that would need to be identified when the browser aggregation tool runs all the underlying build_runner commands. It might be possible for us to refactor wdesk_sdk to not use a custom build.test.yaml, but there may be other situations where we need to provide specific build arguments to the browser aggregation tool for it to forward along to the build_runner commands it runs.

Currently when running in "args" mode, the output includes all the build arguments used to run the underlying build_runner commands. So, for example, if you need to pass `--build-args="-c test"` to the browser aggregation tool then it will regurgitate `-c test` back to you in the string it returns. When consuming this in a tool like `WorkivaTestTool`, that isn't necessary because `WorkivaTestTool` will most likely also apply `-c test` when it runs the actual test command, which would result in `-c test -c test` being passed to the test command. It would probably work, but it doesn't feel as tidy as it could be.

### Solution:
- Hardcoded `--delete-conflicting-outputs` in the first `build_runner` command that is executed by the browser aggregation tool
- Added support for `--build-args` to the browser aggregation tool
- Updated the "args" mode of the browser aggregation tool so it doesn't parrot back the build arguments it passes to the build_runner commands