### PR TITLE
Fix auto_apply config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.1
+
+- Bug fix: change the `auto_apply` config for this builder from `root_package`
+to `dependents`. This ensures that the builder is automatically applied only to
+packages that directly depend on it. This fixes a scenario where an unexpected
+version of `test_html_builder` could be applied to the root package.
+
 ## 2.1.0
 
 - Add support for `--build-args` to the browser aggregation feature.

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ builders:
       $test$:
         - templates/default_template.html
         - test_html_builder_config.json
-    auto_apply: root_package
+    auto_apply: dependents
     build_to: cache
     runs_before:
       - build_test|test_bootstrap


### PR DESCRIPTION
Change the `auto_apply` config for this builder from `root_package` to `dependents`. This ensures that the builder is automatically applied _only_ to packages that directly depend on it. This fixes a scenario where an unexpected version of `test_html_builder` could be applied to the root package.