### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/bin/browser_aggregate_tests.dart
+++ b/bin/browser_aggregate_tests.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:io';
 
 import 'package:args/args.dart';

--- a/example/project/test/templates/css_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/css_template.browser_aggregate_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:test/test.dart';
 

--- a/example/project/test/templates/default_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/default_template.browser_aggregate_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:test/test.dart';
 

--- a/example/project/test/templates/script_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/script_template.browser_aggregate_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:test/test.dart';
 

--- a/example/project/test/unit/css_test.dart
+++ b/example/project/test/unit/css_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:html';
 

--- a/example/project/test/unit/custom_html_test.dart
+++ b/example/project/test/unit/custom_html_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:html';
 

--- a/example/project/test/unit/no_html_test.dart
+++ b/example/project/test/unit/no_html_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:test/test.dart';
 
 void main() {

--- a/example/project/test/unit/script_test.dart
+++ b/example/project/test/unit/script_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:js';
 

--- a/test/bin/browser_aggregate_tests_test.dart
+++ b/test/bin/browser_aggregate_tests_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 @Timeout(Duration(minutes: 1))
 import 'package:path/path.dart' as p;

--- a/test/lib/aggregate_test_builder_test.dart
+++ b/test/lib/aggregate_test_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:convert';
 

--- a/test/lib/config_test.dart
+++ b/test/lib/config_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:build/build.dart';
 import 'package:test/test.dart';

--- a/test/lib/dart_test_yaml_builder_test.dart
+++ b/test/lib/dart_test_yaml_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:convert';
 

--- a/test/lib/template_builder_test.dart
+++ b/test/lib/template_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/lib/test_html_builder_test.dart
+++ b/test/lib/test_html_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:convert';
 


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)