### PR TITLE
CPLAT-15693: Fix browser aggregation when used with build filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+- **Bug fix:** using the browser aggregation feature now works with build
+filters. Previously this would fail because the
+`dart_test.browser_aggregate.yaml` output would be filtered out.
+
 ## 2.1.0
 
 - Add support for `--build-args` to the browser aggregation feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 2.2.0
+## 2.1.2
 
 - **Bug fix:** using the browser aggregation feature now works with build
 filters. Previously this would fail because the
 `dart_test.browser_aggregate.yaml` output would be filtered out.
+
+## 2.1.1
+
+- Widen some dependency ranges to resolve on Dart 2.13.
 
 ## 2.1.0
 

--- a/build.yaml
+++ b/build.yaml
@@ -10,9 +10,9 @@ builders:
     builder_factories:
       - testHtmlBuilder
     build_extensions:
-      $test$:
-        - templates/default_template.html
-        - test_html_builder_config.json
+      $package$:
+        - test/templates/default_template.html
+        - test/test_html_builder_config.json
     auto_apply: root_package
     build_to: cache
     runs_before:
@@ -24,9 +24,6 @@ builders:
       - test_html_builder|aggregator
       - test_html_builder|dart_test_yaml
       - test_html_builder|templates
-    defaults:
-      generate_for:
-        - test/**
 
   test_html_builder|aggregator:
     import: "package:test_html_builder/builder.dart"
@@ -61,11 +58,6 @@ builders:
     builder_factories:
       - dartTestYamlBuilder
     build_extensions:
-      # TODO: once on latest Dart and build_runner, use this instead:
-      # $package$:
-      $test$:
-        - dart_test.browser_aggregate.yaml
+      $package$:
+        - test/dart_test.browser_aggregate.yaml
     build_to: source
-    defaults:
-      generate_for:
-        - test/**

--- a/example/project/dart_test.browser_aggregate.yaml
+++ b/example/project/dart_test.browser_aggregate.yaml
@@ -1,0 +1,8 @@
+presets:
+  browser-aggregate:
+    platforms: [chrome]
+    paths:
+      - test/templates/css_template.browser_aggregate_test.dart
+      - test/templates/script_template.browser_aggregate_test.dart
+      - test/templates/default_template.browser_aggregate_test.dart
+      - test/unit/custom_html_test.dart

--- a/example/project/pubspec.yaml
+++ b/example/project/pubspec.yaml
@@ -2,10 +2,13 @@ name: test_html_builder_example_project
 version: 0.0.0
 publish_to: none
 
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+
 dev_dependencies:
-  build_runner: ^1.7.1
-  build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.6.3
+  build_runner: '>=1.10.1 <3.0.0'
+  build_test: '>=1.2.1 <3.0.0'
+  build_web_compilers: '>=2.9.0 <4.0.0'
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   test: ^1.15.7
   test_html_builder:

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -20,8 +20,10 @@ import 'src/builder.dart';
 TestHtmlBuilder testHtmlBuilder(BuilderOptions options) =>
     TestHtmlBuilder(TestHtmlBuilderConfig.fromBuilderOptions(options));
 
-AggregateTestBuilder aggregateTestBuilder(_) => AggregateTestBuilder();
+AggregateTestBuilder aggregateTestBuilder(BuilderOptions _) =>
+    AggregateTestBuilder();
 
-TemplateBuilder templateBuilder(_) => TemplateBuilder();
+TemplateBuilder templateBuilder(BuilderOptions _) => TemplateBuilder();
 
-DartTestYamlBuilder dartTestYamlBuilder(_) => DartTestYamlBuilder();
+DartTestYamlBuilder dartTestYamlBuilder(BuilderOptions _) =>
+    DartTestYamlBuilder();

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -36,9 +36,9 @@ class TestHtmlBuilder implements Builder {
 
   @override
   final buildExtensions = {
-    r'$test$': [
-      'templates/default_template.html',
-      'test_html_builder_config.json',
+    r'$package$': [
+      'test/templates/default_template.html',
+      'test/test_html_builder_config.json',
     ]
   };
 
@@ -250,9 +250,7 @@ class TemplateBuilder implements Builder {
 class DartTestYamlBuilder extends Builder {
   @override
   final buildExtensions = const {
-    // TODO: once on latest Dart and build_runner, use this:
-    // r'$package$': ['dart_test.browser_aggregate.yaml'],
-    r'$test$': ['dart_test.browser_aggregate.yaml'],
+    r'$package$': ['test/dart_test.browser_aggregate.yaml'],
   };
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,23 +13,23 @@ executables:
   browser_aggregate_tests:
 
 dependencies:
-  args: ^1.6.0
-  build: ^1.1.4
-  dart_style: ^1.3.6
-  glob: ^1.1.7
-  json_annotation: ^3.0.0
-  path: ^1.6.4
+  args: '>=1.6.0 <3.0.0'
+  build: '>=1.3.0 <3.0.0'
+  dart_style: '>=1.3.6 <3.0.0'
+  glob: '>=1.2.0 <3.0.0'
+  json_annotation: ^3.1.1
+  path: ^1.7.0
   test: ^1.15.7
   test_core: ^0.3.11+4
   yaml: ^2.2.1
 
 dev_dependencies:
-  build_runner: ^1.3.0
-  build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.3.0
-  dependency_validator: ^2.0.0
+  build_runner: '>=1.10.1 <3.0.0'
+  build_test: '>=1.2.1 <3.0.0'
+  build_web_compilers: ^2.9.0
+  dependency_validator: ^2.0.1
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
-  pedantic: ^1.8.0
+  pedantic: ^1.9.2
   test_descriptor: ^1.2.0
   test_process: ^1.0.5
 
@@ -37,6 +37,7 @@ dev_dependencies:
   # uncomment this and comment out the test_html_builder definition in
   # `build.yaml`.
   # json_serializable: ^3.0.0
+  # json_serializable: ^4.0.0
 
 dependency_validator:
   ignore:

--- a/test/lib/test_html_builder_test.dart
+++ b/test/lib/test_html_builder_test.dart
@@ -13,7 +13,7 @@ void main() {
     });
     final builder = TestHtmlBuilder(config);
     await testBuilder(builder, {
-      r'a|test/$test$': '',
+      r'a|$package$': '',
     }, outputs: {
       'a|test/templates/default_template.html': '''<!doctype html>
 <html>


### PR DESCRIPTION
# [CPLAT-15693](https://jira.atl.workiva.net/browse/CPLAT-15693)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-15693)

- Updated dependencies to work on 2.7 and 2.13
- Used `$package$` instead of `$test$`, which will always be an input
(even if build filters are used)

## Testing
- From the `example/project/` directory on Dart 2.7:
  - [ ] Note that using build filters when browser aggregation is enabled currently fails:
    - Check out the `master` branch
    - Run `pub upgrade`
    - Run `pub run build_runner test --build-filter="test/unit/no_html_test**" -- test/unit/no_html_test.dart`
    - Should see the following error:

    ```
    Error on line 6, column 10 of dart_test.yaml: Cannot open file, path = './test/dart_test.browser_aggregate.yaml' (OS Error: No such file or directory, errno = 2)
      ╷
    6 │ include: test/dart_test.browser_aggregate.yaml
      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      ╵
    ```
  - [ ] Verify that this branch fixes that issue:
    - Checkout this `fix_build_filters_with_browser_aggregation` branch
    - Reset your working tree - make sure that the `dart_test.browser_aggregate.yaml` file isn't deleted
    - Run `pub upgrade`
    - Run `pub run build_runner test --build-filter="test/unit/no_html_test**" -- test/unit/no_html_test.dart`
    - Verify that it passes