### PR TITLE
Treat Dart 2.13.4 as the primary SDK target for CI

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, beta, dev ]
+        sdk: [ 2.7.2, 2.13.4, stable, beta, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
@@ -26,8 +26,8 @@ jobs:
       - name: Validate dependencies
         run: pub run dependency_validator
       - name: Check formatting
-        run: dartfmt -w .
-        if: ${{ matrix.sdk == '2.7.2' }}
+        run: dart format --set-exit-if-changed -o none .
+        if: ${{ matrix.sdk == '2.13.4' }}
       - name: Analyze project source
         run: dartanalyzer .
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.2
+
+- Treat Dart 2.13.4 as the primary SDK target for CI.
+
+## 2.1.1
+
+- Widen dependency ranges blocking Dart 2.13.
+
 ## 2.1.0
 
 - Add support for `--build-args` to the browser aggregation feature.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.7
+FROM google/dart:2.13.4
 WORKDIR /build/
 ADD pubspec.yaml /build
 RUN pub get


### PR DESCRIPTION
### Problem:
We treat Dart 2.7.2 as our primary SDK target when running CI. At Workiva, we're transitioning to Dart 2.13.4 as our primary version for development. Perhaps we should treat it as our primary target in CI.

### Solution:
- Updated Dockerfile to use the google/dart:2.13.4 image.
- Updated dart_ci.yaml to explicitly run on Dart 2.13.4 and make sure we're checking formatting on that version of the SDK.
  - I left 2.7.2 in the test matrix since we technically still support older versions of Dart.