### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, 2.13.4, stable, beta, dev ]
+        sdk: [ 2.13.4, stable, beta, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pub/
 .packages
 pubspec.lock
+build/

--- a/example/project/pubspec.yaml
+++ b/example/project/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 dev_dependencies:
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.6.3
+  build_web_compilers: ^2.12.0
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   test: ^1.15.7
   test_html_builder:

--- a/example/project/pubspec.yaml
+++ b/example/project/pubspec.yaml
@@ -10,3 +10,6 @@ dev_dependencies:
   test: ^1.15.7
   test_html_builder:
     path: ../..
+
+environment:
+  sdk: '>=2.11.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
 
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"
 
 executables:
   browser_aggregate_tests:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.3.0
+  build_web_compilers: ^2.12.0
   dependency_validator: ^2.0.0
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   pedantic: ^1.8.0

--- a/test/bin/browser_aggregate_tests_test.dart
+++ b/test/bin/browser_aggregate_tests_test.dart
@@ -13,7 +13,7 @@ void main() {
     await d.dir('pkg', [
       d.file('pubspec.yaml', '''name: pkg
 environment:
-  sdk: '>=2.7.2 <3.0.0'
+  sdk: '>=2.11.0 <3.0.0'
 dev_dependencies:
   build_runner: any
   build_test: any


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)