### PR TITLE
Add `--verbose` flag to executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 2.3.0
+
+- Add a `--verbose` flag to `test_html_builder:browser_aggregate_tests`
+executable so that build logs can still be seen when running with `--mode=args`.
+
 ## 2.2.0
+
 - Add ability to 'randomize' tests within the aggregated test file with the
 `randomize_ordering_seed` option.
 

--- a/example/project/.gitignore
+++ b/example/project/.gitignore
@@ -1,0 +1,1 @@
+test/**/*.browser_aggregate_test.dart

--- a/example/project/build.yaml
+++ b/example/project/build.yaml
@@ -4,6 +4,7 @@ targets:
       test_html_builder:
         options:
           browser_aggregation: true
+          randomize_ordering_seed: random
           templates:
             "test/templates/script_template.html":
               - "test/unit/script_test.dart"

--- a/example/project/dart_test.browser_aggregate.yaml
+++ b/example/project/dart_test.browser_aggregate.yaml
@@ -1,8 +1,0 @@
-presets:
-  browser-aggregate:
-    platforms: [chrome]
-    paths:
-      - test/templates/css_template.browser_aggregate_test.dart
-      - test/templates/script_template.browser_aggregate_test.dart
-      - test/templates/default_template.browser_aggregate_test.dart
-      - test/unit/custom_html_test.dart

--- a/example/project/test/templates/css_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/css_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/css_test.dart' as unit_css_test;
-
-void main() {
-  unit_css_test.main();
-}

--- a/example/project/test/templates/default_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/default_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/no_html_test.dart' as unit_no_html_test;
-
-void main() {
-  unit_no_html_test.main();
-}

--- a/example/project/test/templates/script_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/script_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/script_test.dart' as unit_script_test;
-
-void main() {
-  unit_script_test.main();
-}


### PR DESCRIPTION
When using `randomize_ordering_seed: "random"`, being able to see the seed that is chose at random in the logs is critical to being able to debug issues that might arise due to the randomization. Currently, if that build step happens when running `dart run test_html_builder:browser_aggregate_tests --mode=args`, the build output containing the log with the random seed will be hidden.

This PR adds a `--verbose` flag that, when used with `--mode=args`, will still print the build logs to stderr. It also changes all other logs to print to stderr except the one that actually prints the build/test args so that tools that need to parse those out can do so easily.