### PR TITLE
CPLAT-16119: Print the `randomize_ordering_seed` when running each browser aggregate test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 2.2.1
+
+- When running tests, print the `randomize_ordering_seed` that was used to build
+each browser aggregate test file. This should make it easier to debug test
+failures that occur due to the randomized ordering.
+
 ## 2.2.0
+
 - Add ability to 'randomize' tests within the aggregated test file with the
 `randomize_ordering_seed` option.
 

--- a/example/project/.gitignore
+++ b/example/project/.gitignore
@@ -1,0 +1,1 @@
+test/**/*.browser_aggregate_test.dart

--- a/example/project/build.yaml
+++ b/example/project/build.yaml
@@ -4,6 +4,7 @@ targets:
       test_html_builder:
         options:
           browser_aggregation: true
+          randomize_ordering_seed: random
           templates:
             "test/templates/script_template.html":
               - "test/unit/script_test.dart"

--- a/example/project/dart_test.browser_aggregate.yaml
+++ b/example/project/dart_test.browser_aggregate.yaml
@@ -1,8 +1,0 @@
-presets:
-  browser-aggregate:
-    platforms: [chrome]
-    paths:
-      - test/templates/css_template.browser_aggregate_test.dart
-      - test/templates/script_template.browser_aggregate_test.dart
-      - test/templates/default_template.browser_aggregate_test.dart
-      - test/unit/custom_html_test.dart

--- a/example/project/test/templates/css_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/css_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/css_test.dart' as unit_css_test;
-
-void main() {
-  unit_css_test.main();
-}

--- a/example/project/test/templates/default_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/default_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/no_html_test.dart' as unit_no_html_test;
-
-void main() {
-  unit_no_html_test.main();
-}

--- a/example/project/test/templates/script_template.browser_aggregate_test.dart
+++ b/example/project/test/templates/script_template.browser_aggregate_test.dart
@@ -1,8 +1,0 @@
-@TestOn('browser')
-import 'package:test/test.dart';
-
-import '../unit/script_test.dart' as unit_script_test;
-
-void main() {
-  unit_script_test.main();
-}

--- a/test/lib/aggregate_test_builder_test.dart
+++ b/test/lib/aggregate_test_builder_test.dart
@@ -119,6 +119,8 @@ import '../d_test.dart' as d_test;
 import '../e_test.dart' as e_test;
 
 void main() {
+  print(
+      'test/templates/default_template.html built with `randomize_ordering_seed: "2"`');
   c_test.main();
   a_test.main();
   e_test.main();


### PR DESCRIPTION

When using `randomize_ordering_seed: "random"`, being able to see the seed that is chosen at random in the logs is critical to being able to debug issues that might arise due to the randomization. Currently, if that build step happens when running `dart run test_html_builder:browser_aggregate_tests --mode=args`, the build output containing the log with the random seed will be hidden.

This PR adds a line to the `main()` block of each aggregate file that prints the seed that was used to build it. With this change, the seed will be printed in the test logs right before running all of the tests in each aggregate file, like so:

```
00:02 +0: loading test/templates/default_template.browser_aggregate_test.dart                                         
test/templates/default_template.html built with randomize_ordering_seed: 2774528195
00:02 +0: loading test/templates/css_template.browser_aggregate_test.dart                                             
test/templates/css_template.html built with randomize_ordering_seed: 2774528195
00:02 +0: loading test/templates/script_template.browser_aggregate_test.dart                                          
test/templates/script_template.html built with randomize_ordering_seed: 2774528195
00:02 +4: All tests passed!      
```