### PR TITLE
Workaround `$package$` outputs not being regenerated after being deleted during "conflicting outputs" step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2
+
+- When browser aggregation is enabled in `build.yaml`, ensure that the
+`test/dart_test.browser_aggregate.yaml` asset is always generated even when
+`--build-filter` options are used. This is a workaround only necessary with
+older versions of the `build` dependencies and is fixed in the latest.
+
 ## 2.2.1
 
 - When running tests, print the `randomize_ordering_seed` that was used to build

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -270,6 +270,25 @@ class TemplateBuilder implements Builder {
         .replaceFirst('{{testScript}}', link)
         .replaceAll('{{testName}}', testName);
     await buildStep.writeAsString(htmlId, htmlContents);
+
+    // WORKAROUND: This is a temporary step only needed in 2.x to workaround a
+    // bug where running `dart run build_runner build` with `--build-filter`s
+    // deletes outputs that use `$package$` as the input. This results in the
+    // `test/dart_test.browser_aggregate.yaml` file not existing, which causes
+    // the test runner to fail when parsing the root `dart_test.yaml` that tries
+    // to include that generated file. By reading this file in this build step,
+    // we force the build system to generate it if it doesn't yet exist.
+    //
+    // In the 3.x release of this package, newer versions of build packages will
+    // be resolvable and those versions include a fix for this behavior, so this
+    // workaround will not be needed.
+    if (_config.browserAggregation) {
+      final browserAggregateTestYaml = AssetId(
+          buildStep.inputId.package, 'test/dart_test.browser_aggregate.yaml');
+      if (await buildStep.canRead(browserAggregateTestYaml)) {
+        await buildStep.readAsString(browserAggregateTestYaml);
+      }
+    }
   }
 
   TestHtmlBuilderConfig _config;


### PR DESCRIPTION
This is a temporary step only needed in 2.x to workaround a bug where running `dart run build_runner build` with `--build-filter`s deletes conflicting outputs and then doesn't regenerate the ones that use `$package$` as the input. This results in the `test/dart_test.browser_aggregate.yaml` file not existing, which causes the test runner to fail when parsing the root `dart_test.yaml` that tries to include that generated file. By reading this file in the `TemplateBuilder` step, we force the build system to generate it if it doesn't yet exist.

In the 3.x release of this package, newer versions of build packages will be resolvable and those versions include a fix for this behavior, so this workaround will not be needed.