### PR TITLE
FEA-274: Sort the imports and test invocations in aggregated tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.1
+
+- Sort the imports and test invocations when generating aggregate tests. This
+ensures consistent builder outputs across different operating systems.
+
 ## 3.0.0
 
 - Migrate to null safety.

--- a/test/bin/browser_aggregate_tests_test.dart
+++ b/test/bin/browser_aggregate_tests_test.dart
@@ -138,7 +138,8 @@ void main() {
           emitsThrough('Found 1 aggregate tests to run.'),
           emitsThrough(
               'dart run build_runner test --build-filter=test/templates/default_template.browser_aggregate_test.** -- --preset=browser-aggregate'),
-          emitsThrough(contains('All tests passed!')),
+          emitsThrough(
+              anyOf(contains('All tests passed!'), contains('1 test passed.'))),
         ]));
     await process.shouldExit(0);
   });
@@ -160,7 +161,8 @@ void main() {
           emitsThrough('Found 1 aggregate tests to run.'),
           emitsThrough(
               'dart run build_runner test --release -c custom --build-filter=test/templates/default_template.browser_aggregate_test.** -- --preset=browser-aggregate'),
-          emitsThrough(contains('All tests passed!')),
+          emitsThrough(
+              anyOf(contains('All tests passed!'), contains('1 test passed.'))),
         ]));
     await process.shouldExit(0);
   });

--- a/test/lib/aggregate_test_builder_test.dart
+++ b/test/lib/aggregate_test_builder_test.dart
@@ -140,8 +140,8 @@ void main() {
       final builder = AggregateTestBuilder();
       await testBuilder(builder, {
         'a|test/test_html_builder_config.json': jsonEncode(config),
-        'a|test/foo_test.dart': '',
         'a|test/bar_test.dart': '',
+        'a|test/foo_test.dart': '',
         'a|test/templates/foo_template.html': '',
         'a|test/templates/bar_template.html': '',
       }, outputs: {
@@ -149,12 +149,44 @@ void main() {
             '''@TestOn('browser')
 import 'package:test/test.dart';
 
-import '../foo_test.dart' as foo_test;
 import '../bar_test.dart' as bar_test;
+import '../foo_test.dart' as foo_test;
 
 void main() {
-  foo_test.main();
   bar_test.main();
+  foo_test.main();
+}
+'''
+      });
+    });
+
+    test('sorts the test imports and invocations', () async {
+      final config =
+          TestHtmlBuilderConfig(browserAggregation: true, templates: {
+        'test/templates/foo_template.html': ['test/**_test.dart'],
+      });
+      final builder = AggregateTestBuilder();
+      await testBuilder(builder, {
+        'a|test/test_html_builder_config.json': jsonEncode(config),
+        'a|test/templates/foo_template.html': '',
+        // These three are intentionally unsorted so that this test can verify
+        // that the builder sorts them.
+        'a|test/foo_test.dart': '',
+        'a|test/baz/baz_test.dart': '',
+        'a|test/bar_test.dart': '',
+      }, outputs: {
+        'a|test/templates/foo_template.browser_aggregate_test.dart':
+            '''@TestOn('browser')
+import 'package:test/test.dart';
+
+import '../bar_test.dart' as bar_test;
+import '../baz/baz_test.dart' as baz_baz_test;
+import '../foo_test.dart' as foo_test;
+
+void main() {
+  bar_test.main();
+  baz_baz_test.main();
+  foo_test.main();
 }
 '''
       });


### PR DESCRIPTION
When generating browser aggregate tests, we now sort the imports and test invocations to ensure consistent builder outputs across different operating systems. Previously we were just relying on the order that the underlying filesystem returned files, which varies.