### PR TITLE
FEA-429: Widen `yaml` range to include v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Widen dependency range on `yaml` to allow v3.
+
 ## 2.2.2
 
 - When browser aggregation is enabled in `build.yaml`, ensure that the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.7.0
   test: ^1.15.7
   test_core: ^0.3.11+4
-  yaml: ^2.2.1
+  yaml: '>=2.2.1 <4.0.0'
 
 dev_dependencies:
   build_runner: '>=1.10.1 <3.0.0'


### PR DESCRIPTION
This is a backpatch to the 2.x line to widen the `yaml` dependency range. This will allow consumers still on 2.x to resolve to newer versions of critical dependencies, like `analyzer`.