### PR TITLE
Output browser aggregation file in previous location for ease of upgrade

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -16,14 +16,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: stable
+          sdk: 2.18.7
       - run: dart format --set-exit-if-changed -o none .
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.3
 
+- Compatible with Dart 3.
 - For consumers using the browser aggregation feature, update the builder to
 also output the `dart_test.browser_aggregate.yaml` config file to the same
 location used in v2: the `test/` directory. This makes it easier for consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.3
+
+- For consumers using the browser aggregation feature, update the builder to
+also output the `dart_test.browser_aggregate.yaml` config file to the same
+location used in v2: the `test/` directory. This makes it easier for consumers
+to upgrade from v2 to v3.
+
 ## 3.0.1
 
 - Sort the imports and test invocations when generating aggregate tests. This

--- a/build.yaml
+++ b/build.yaml
@@ -19,16 +19,16 @@ builders:
     auto_apply: root_package
     build_to: cache
     runs_before:
-      - build_test|test_bootstrap
-      - test_html_builder|aggregator
-      - test_html_builder|dart_test_yaml
-      - test_html_builder|templates
+      - build_test:test_bootstrap
+      - test_html_builder:aggregator
+      - test_html_builder:dart_test_yaml
+      - test_html_builder:templates
     applies_builders:
-      - test_html_builder|aggregator
-      - test_html_builder|dart_test_yaml
-      - test_html_builder|templates
+      - test_html_builder:aggregator
+      - test_html_builder:dart_test_yaml
+      - test_html_builder:templates
 
-  test_html_builder|aggregator:
+  test_html_builder:aggregator:
     import: "package:test_html_builder/builder.dart"
     builder_factories:
       - aggregateTestBuilder
@@ -38,14 +38,14 @@ builders:
     build_to: source
     is_optional: true
     runs_before:
-      - test_html_builder|dart_test_yaml
-      - test_html_builder|templates
-      - build_test|test_bootstrap
+      - test_html_builder:dart_test_yaml
+      - test_html_builder:templates
+      - build_test:test_bootstrap
     defaults:
       generate_for:
         - test/**
 
-  test_html_builder|templates:
+  test_html_builder:templates:
     import: "package:test_html_builder/builder.dart"
     builder_factories:
       - templateBuilder
@@ -57,11 +57,12 @@ builders:
       generate_for:
         - test/**
 
-  test_html_builder|dart_test_yaml:
+  test_html_builder:dart_test_yaml:
     import: "package:test_html_builder/builder.dart"
     builder_factories:
       - dartTestYamlBuilder
     build_extensions:
       $package$:
         - dart_test.browser_aggregate.yaml
+        - test/dart_test.browser_aggregate.yaml
     build_to: source

--- a/example/project/pubspec.yaml
+++ b/example/project/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dev_dependencies:
   build_runner: ^2.1.2
   build_test: ^2.1.3
-  build_web_compilers: ^3.0.0
+  build_web_compilers: '>=3.0.0 <5.0.0'
   test: ^1.17.12
   test_html_builder:
     path: ../..

--- a/example/project/test/dart_test.browser_aggregate.yaml
+++ b/example/project/test/dart_test.browser_aggregate.yaml
@@ -1,0 +1,8 @@
+presets:
+  browser-aggregate:
+    platforms: [chrome]
+    paths:
+      - test/templates/css_template.browser_aggregate_test.dart
+      - test/templates/script_template.browser_aggregate_test.dart
+      - test/templates/default_template.browser_aggregate_test.dart
+      - test/unit/custom_html_test.dart

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -295,7 +295,10 @@ class TemplateBuilder implements Builder {
 class DartTestYamlBuilder extends Builder {
   @override
   final buildExtensions = const {
-    r'$package$': ['dart_test.browser_aggregate.yaml'],
+    r'$package$': [
+      'dart_test.browser_aggregate.yaml',
+      'test/dart_test.browser_aggregate.yaml',
+    ],
   };
 
   @override
@@ -329,6 +332,10 @@ class DartTestYamlBuilder extends Builder {
     final outputId =
         AssetId(buildStep.inputId.package, 'dart_test.browser_aggregate.yaml');
     await buildStep.writeAsString(outputId, contents.toString());
+
+    final backwardsCompatOutputId = AssetId(
+        buildStep.inputId.package, 'test/dart_test.browser_aggregate.yaml');
+    await buildStep.writeAsString(backwardsCompatOutputId, contents.toString());
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
 
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 executables:
   browser_aggregate_tests:
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.2
   build_test: ^2.1.3
-  build_web_compilers: ^3.0.0
+  build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.1.0
   pedantic: ^1.11.1
   test_descriptor: ^2.0.0

--- a/test/lib/dart_test_yaml_builder_test.dart
+++ b/test/lib/dart_test_yaml_builder_test.dart
@@ -38,6 +38,13 @@ void main() {
     paths:
       - test/foo_template.browser_aggregate_test.dart
       - test/custom_test.dart
+''',
+        'a|test/dart_test.browser_aggregate.yaml': '''presets:
+  browser-aggregate:
+    platforms: [chrome]
+    paths:
+      - test/foo_template.browser_aggregate_test.dart
+      - test/custom_test.dart
 '''
       });
     });


### PR DESCRIPTION
The only breaking change in v3 (other than NNBD) was:

> the browser aggregation feature now outputs the `dart_test.browser_aggregate.yaml` config file to the root of your package instead of the `test/` directory.

To make the upgrade story from v2 to v3 easier, this PR updates the builder to _also_ output that file to the previous location in `test/` so that consumers don't need to immediately update their `dart_test.yaml` config when upgrading.