### PR TITLE
Backpatch json_annotation_3_1_1 test_html_builder v2

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -19,7 +19,7 @@ library lib.src.config;
 
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'dart:math';
 
 part 'config.g.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   build: '>=1.3.0 <3.0.0'
   dart_style: '>=1.3.6 <3.0.0'
   glob: '>=1.2.0 <3.0.0'
-  json_annotation: ^3.1.1
+  json_annotation_3_1_1: { hosted: { name: json_annotation_3_1_1, url: https://pub.workiva.org }, version: ^5.3.3 }
   path: ^1.7.0
   test: ^1.15.7
   test_core: ^0.3.11+4
@@ -30,7 +30,7 @@ dev_dependencies:
   dependency_validator: ^2.0.1
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   pedantic: ^1.9.2
-  test_descriptor: ^1.2.0
+  test_descriptor: '>=1.2.0 <3.0.0'
   test_process: ^1.0.5
 
   # If changes are made to `lib/src/config.dart` and regeneration is needed,
@@ -38,6 +38,7 @@ dev_dependencies:
   # `build.yaml`.
   # json_serializable: ^3.0.0
   # json_serializable: ^4.0.0
+  # json_serializable_3_5_2: { hosted: { name: json_serializable_3_5_2, url: https://pub.workiva.org }, version: ^5.3.3 }
 
 dependency_validator:
   ignore:


### PR DESCRIPTION
Summary
---
In order to upgrade to analyzer 2, we need to handle json_serializable.
This PR swaps out the json_serializable and json_annotation dependencies
with our temporary internally published versions that allow analyzer 2.
We can't move directly to json4, since it only generates nullsafe code
and the packages using json_serializable are not ready to be migrated
to null safety yet.

json_annotation_3_1_1 and json_serializable_3_5_2
are renamed versions of those packages at those versions.
The version ^5.3.3 is irrelevant as the code is at 3.1.1 and 3.5.2 respectively

### Changes
- swap out the dependency in pubspec.yaml files
- swap the name of the dependencies in import statements in Dart files
- swap the name of the builder in build.yaml files

### QA
- pub get should resolve to the swapped dependencies
- CI should pass and the generated code for json serialization should be identical

For more info, visit `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/swap_to_internal_json_serializable`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/swap_to_internal_json_serializable)