### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart format --set-exit-if-changed -o none .
   test:
     runs-on: ubuntu-latest

--- a/tool/test_example.sh
+++ b/tool/test_example.sh
@@ -6,7 +6,7 @@ cd example/project
 dart pub get
 dart run build_runner build --delete-conflicting-outputs
 dart run build_runner test
-dart test_html_builder:browser_aggregate_tests
+dart run test_html_builder:browser_aggregate_tests
 
 # These commands target a scenario where there is no build cache and someone
 # uses build filters to run a subset of tests.

--- a/tool/test_example.sh
+++ b/tool/test_example.sh
@@ -6,7 +6,7 @@ cd example/project
 dart pub get
 dart run build_runner build --delete-conflicting-outputs
 dart run build_runner test
-dart run test_html_builder:browser_aggregate_tests
+dart test_html_builder:browser_aggregate_tests
 
 # These commands target a scenario where there is no build cache and someone
 # uses build filters to run a subset of tests.


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_2_19`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_2_19)