### PR TITLE
Widen allowed range for test_core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pub/
 .packages
 pubspec.lock
+.idea

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   json_annotation: ^4.1.0
   path: ^1.8.0
   test: ^1.17.12
-  test_core: ^0.4.2
+  test_core: ">=0.4.2 <0.6.0"
   yaml: ^3.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Consumers would like to allow for test 1.24.3 -- to do that, we have to allow for test_core 0.5.X

This PR widens the dependency range to allow 0.5.X -- local testing in esg_ui is not finding any obvious problems with this.