### PR TITLE
FEDX-1709: Workiva Analysis Options v2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:workiva_analysis_options/v2.yaml
-include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:
   exclude:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:workiva_analysis_options/v2.yaml
 include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   pedantic: ^1.11.1
   test_descriptor: ^2.0.0
   test_process: ^2.0.2
+  workiva_analysis_options: ^1.4.1
 
   # If changes are made to `lib/src/config.dart` and regeneration is needed,
   # uncomment this and comment out the test_html_builder definition in

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ dev_dependencies:
   build_test: ^2.1.3
   build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.1.0
-  pedantic: ^1.11.1
   test_descriptor: ^2.0.0
   test_process: ^2.0.2
   workiva_analysis_options: ^1.4.1


### PR DESCRIPTION
# [FEDX-1709](https://jira.atl.workiva.net/browse/FEDX-1709)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1709)

This PR bumps/adds workiva_analysis_options to v2. This is being done in an effort to adopt consistency in
`analysis_options.yaml` files across the codebase, and ensure all developers are using the most up to date
functionality that the dart analyzer can provide.

Failing CI will be evaluated by someone from FEDX and resolved. We will reach out when the pr is ready for review.

If you have any questions, concerns, or opinions, please reach out to #support-frontend-dx.

[_Created by Sourcegraph batch change `Workiva/workiva_analysis_options_v2`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/workiva_analysis_options_v2)