### PR TITLE
FEDX-1709 Batch/fedx/workiva analysis options v2

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -25,7 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.19.6, stable, beta ]
+        sdk: [ 2.19.6 ]
+        # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
+        # sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
@@ -46,7 +48,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.19.6, stable, beta ]
+        sdk: [ 2.19.6 ]
+        # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
+        # sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:workiva_analysis_options/v2.yaml
-include: package:pedantic/analysis_options.1.8.0.yaml
 analyzer:
   exclude:
     - example/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
+include: package:workiva_analysis_options/v2.yaml
 include: package:pedantic/analysis_options.1.8.0.yaml
-
 analyzer:
   exclude:
     - example/**
@@ -7,9 +7,3 @@ analyzer:
   language:
     strict-inference: true
     strict-raw-types: true
-
-linter:
-  rules:
-    - avoid_types_on_closure_parameters
-    - prefer_void_to_null
-    - void_checks

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   pedantic: ^1.11.1
   test_descriptor: ^2.0.0
   test_process: ^2.0.2
+  workiva_analysis_options: ^1.4.1
 
   # If changes are made to `lib/src/config.dart` and regeneration is needed,
   # uncomment this and comment out the test_html_builder definition in

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ executables:
 dependencies:
   args: ^2.3.0
   build: ^2.1.0
+  build_runner: ^2.3.3
   dart_style: ^2.1.1
   glob: ^2.0.1
   json_annotation: ^4.1.0
@@ -28,7 +29,6 @@ dev_dependencies:
   build_test: ^2.1.3
   build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.1.0
-  pedantic: ^1.11.1
   test_descriptor: ^2.0.0
   test_process: ^2.0.2
   workiva_analysis_options: ^1.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  build_runner: ^2.1.2
   build_test: ^2.1.3
   build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ executables:
 dependencies:
   args: ^2.3.0
   build: ^2.1.0
-  build_runner: ^2.3.3
   dart_style: ^2.1.1
   glob: ^2.0.1
   json_annotation: ^4.1.0
@@ -25,6 +24,7 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
+  build_runner: ^2.1.2
   build_test: ^2.1.3
   build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.1.0


### PR DESCRIPTION
## Update
This was originally closed [here](https://github.com/Workiva/test_html_builder/pull/49) because of failing tests in master, but has been re-implemented with this PR. We are now focusing on implementing v2 for workiva analysis options and commenting out the dart 3 stable and beta CI tests for now. Work to resolve those issues will be handled with [FEDX-1911](https://jira.atl.workiva.net/browse/FEDX-1911).

## What was done
This PR bumps/adds workiva\_analysis\_options to v2. This is being done in an effort to adopt consistency in {{analysis\_options.yaml}} files across the codebase, and ensure all developers are using the most up to date functionality that the dart analyzer can provide.

Failing CI will be evaluated by someone from FEDX and resolved. We will reach out when the pr is ready for review.
(We are stopping dart 3 stable and beta CI tests since they are even failing in master. Future work will resolve this (see Update section above)

If you have any questions, concerns, or opinions, please reach out to #support\-frontend\-dx.

[_Created by Sourcegraph batch change {{Workiva/workiva\_analysis\_options\_v2}}._|https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/workiva_analysis_options_v2]

