### PR TITLE
FEDX-1911: Fix Dart 3 tests

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -25,9 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.19.6 ]
         # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
-        # sdk: [ 2.19.6, stable, beta ]
+        sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
@@ -48,9 +47,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.19.6 ]
         # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
-        # sdk: [ 2.19.6, stable, beta ]
+        sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
         sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +46,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add stable and beta sdk's as a separate effort (FEDX-1911)[https://jira.atl.workiva.net/browse/FEDX-1911]
         sdk: [ 2.19.6, stable, beta ]
     steps:
       - uses: actions/checkout@v4

--- a/bin/browser_aggregate_tests.dart
+++ b/bin/browser_aggregate_tests.dart
@@ -171,6 +171,7 @@ Future<void> buildTests(List<String> testPaths,
     'run',
     'build_runner',
     'build',
+    '--delete-conflicting-outputs',
     ...buildRunnerBuildArgs(testPaths,
         release: release, userBuildArgs: userBuildArgs),
   ];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   json_annotation: ^4.1.0
   path: ^1.8.0
   test: ^1.17.12
-  test_core: ">=0.4.2 <0.6.0"
+  test_core: ">=0.4.2 <0.7.0"
   yaml: ^3.1.0
 
 dev_dependencies:

--- a/test/bin/browser_aggregate_tests_test.dart
+++ b/test/bin/browser_aggregate_tests_test.dart
@@ -95,7 +95,7 @@ void main() {
           emitsThrough('Reading browser aggregate test config...'),
           emitsThrough('Found 1 aggregate tests to run.'),
           emitsThrough(
-              'dart run build_runner build --build-filter=test/templates/default_template.browser_aggregate_test.**'),
+              'dart run build_runner build --delete-conflicting-outputs --build-filter=test/templates/default_template.browser_aggregate_test.**'),
           emitsThrough(contains('Succeeded')),
         ]));
     await process.shouldExit(0);
@@ -116,7 +116,7 @@ void main() {
           emitsThrough('Reading browser aggregate test config...'),
           emitsThrough('Found 1 aggregate tests to run.'),
           emitsThrough(
-              'dart run build_runner build -c custom --release --build-filter=test/templates/default_template.browser_aggregate_test.**'),
+              'dart run build_runner build --delete-conflicting-outputs -c custom --release --build-filter=test/templates/default_template.browser_aggregate_test.**'),
           emitsThrough(contains('Succeeded')),
         ]));
     await process.shouldExit(0);


### PR DESCRIPTION
We are trying to get Dart 3 tests working in react-dart with test_html_builder. We hit a dependency constraint issue. This addresses that constraint and re-adds Dart 3 tests to ci. 